### PR TITLE
Add Streamlit ZIP upload with archive dedupe and provenance enhancements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,4 +204,4 @@ Source: [StackHawk](https://www.stackhawk.com/blog/4-best-practices-for-ai-code-
 
 ---
 
-Last updated: 2025-10-11
+Last updated: 2025-10-29

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,49 @@ Goals: reproducibility, privacy, and clarity.
 
 ---
 
+## Security-First Development Rules
+
+Source: [StackHawk](https://www.stackhawk.com/blog/4-best-practices-for-ai-code-security-a-developers-guide/)
+
+### Code Security Standards
+
+* Always use parameterized queries - never string concatenation for database queries
+* Implement proper input validation and sanitization for all user inputs
+* Use secure authentication and authorization patterns
+* Never hardcode secrets, API keys, or passwords in source code
+* Implement proper error handling that doesn't expose sensitive information
+* Follow OWASP Top 10 guidelines for web application security
+
+### Dependency Management
+
+* Only suggest well-maintained packages with recent updates
+* Prefer packages with strong security track records
+* Flag any dependencies that haven't been updated in 12+ months
+* Always check for known vulnerabilities before suggesting packages
+
+### Code Review Requirements
+
+* Generate TODO comments for any code that needs security review
+* Add inline comments explaining security-relevant decisions
+* Flag any code that handles sensitive data for manual review
+* Suggest security test cases for authentication and authorization logic
+
+### Error Handling
+
+* Implement fail-secure patterns (deny by default)
+* Log security events appropriately without exposing sensitive data
+* Use structured error responses that don't leak implementation details
+
+## Healthcare Security Requirements
+
+* Encrypt all PHI at rest and in transit using AES-256 and TLS 1.2+
+* Log all data access for auditing
+* Follow the minimum necessary principle for data access  
+* Use cryptographically secure random number generation
+* Implement session timeouts for sensitive data access
+
+---
+
 ## AI Disclosure
 
 * Generated code must include a brief comment noting that it was AI-assisted.
@@ -113,11 +156,51 @@ Goals: reproducibility, privacy, and clarity.
 
 ---
 
-## Versioning
+## Versioning & Branching Guidelines
 
-* Use **conventional commit messages** (`feat:`, `fix:`, `refactor:`).
-* Avoid multi-purpose commits.
-* Never auto-commit without explicit confirmation.
+### Commit messages
+
+* Use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, etc.)
+* Keep commits atomic and single-purpose — one logical change per commit
+* Write brief, imperative summaries (e.g., `fix: correct null handling in parser`)
+
+### Branch structure
+
+* **main** — always stable, production-ready code  
+* **release/X.Y.Z** — branch from `main`  
+  * Used to integrate multiple features, test, and prepare for tagging  
+* **feature/short-slug** — branch from a `release/X.Y.Z` branch  
+  * Used for developing or refactoring specific features or fixes  
+* Merge completed `release/X.Y.Z` branches back into `main` when verified
+
+### Merging & tagging
+
+* Prefer **squash merges** for feature branches (to keep history readable)
+* Tag the final commit on `main` as `vX.Y.Z` upon release
+* Delete merged branches after confirmation to keep the repo tidy
+
+### Automation rules
+
+* Never auto-commit, merge, or push without explicit human confirmation
+* Always perform `git pull --rebase` before committing to avoid merge noise
+* If conflicts occur, pause for human review — do not attempt auto-resolution
+* Do not modify `.gitignore`, `.gitattributes`, or `.gitmodules` without approval
+
+### Documentation hints (for AI)
+
+* Each release should have a matching entry in `CHANGELOG.md`
+* Include the related issue or PR number in the commit body when available
+* Treat commits as part of the project’s provenance record
+* Include AI-assisted code attribution in the commit body, referencing the prompt(s) and model used
+
+### Issue and milestone linkage
+
+* Each feature or enhancement must have a corresponding **GitHub issue**.
+* The **issue number** defines the branch name:  
+  * Example: `feature/17-notes-viewer`
+* Assign each issue to the appropriate **milestone** (e.g., `v0.2.0`), which maps to the `release/0.2.0` branch.
+* Reference the issue in all commits and PRs using the format `Refs #17` or `Closes #17` as appropriate.
+* Do not merge feature branches that are not tied to an issue and milestone.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ pip install -r requirements.txt
 
 - **Schema & services (`schema.sql`, `services/`)**
   - `schema.sql` defines core tables for patients, providers, encounters,
-    medications, lab results, allergies, insurance coverage, conditions (with codes), procedures,
-    vitals, immunizations, attachments, progress notes, and the `ingested_archive`
-    registry used to track archive hashes and ingestion counts, each linking back to
-    enriched `data_source` metadata.
+    medications, lab results, allergies, insurance coverage, conditions
+    (with codes), procedures, vitals, immunizations, attachments, progress notes,
+    and the `ingested_archive` registry used to track archive hashes and ingestion
+    counts, each linking back to enriched `data_source` metadata (now including
+    `source_archive_id` foreign keys to `ingested_archive`).
   - Service modules encapsulate insert logic, deduplication, and foreign key
     wiring for each domain. `services/data_sources.py` manages provenance rows
     so other modules can reference a shared `data_source_id`, while `services/archives.py`

--- a/README.md
+++ b/README.md
@@ -110,11 +110,13 @@ pip install -r requirements.txt
 - **Schema & services (`schema.sql`, `services/`)**
   - `schema.sql` defines core tables for patients, providers, encounters,
     medications, lab results, allergies, insurance coverage, conditions (with codes), procedures,
-    vitals, immunizations, attachments, and progress notes, each
-    linking back to enriched `data_source` metadata.
+    vitals, immunizations, attachments, progress notes, and the `ingested_archive`
+    registry used to track archive hashes and ingestion counts, each linking back to
+    enriched `data_source` metadata.
   - Service modules encapsulate insert logic, deduplication, and foreign key
     wiring for each domain. `services/data_sources.py` manages provenance rows
-    so other modules can reference a shared `data_source_id`.
+    so other modules can reference a shared `data_source_id`, while `services/archives.py`
+    records archive hashes so duplicate uploads can be flagged safely.
   - `db/schema.py` backfills missing columns, normalizes provider records, and
     adds protective indexes.
 

--- a/db/schema.py
+++ b/db/schema.py
@@ -298,6 +298,7 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
     ensure_encounter_schema(conn)
     ensure_allergy_schema(conn)
     ensure_insurance_schema(conn)
+    ensure_lab_constraints(conn)
     ensure_medication_constraints(conn)
     ensure_immunization_constraints(conn)
     ensure_data_source_columns(conn)
@@ -323,6 +324,28 @@ def ensure_immunization_constraints(conn: sqlite3.Connection) -> None:
                 COALESCE(cvx_code, '')
             )
         """)
+
+
+def ensure_lab_constraints(conn: sqlite3.Connection) -> None:
+    """Enforce uniqueness of lab results by patient, LOINC, and date."""
+    conn.execute("""
+        DELETE FROM lab_result
+              WHERE rowid NOT IN (
+                    SELECT MIN(rowid)
+                      FROM lab_result
+                     GROUP BY patient_id,
+                              COALESCE(loinc_code, ''),
+                              COALESCE(date, '')
+              )
+    """)
+    conn.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_lab_unique_patient_loinc_date
+            ON lab_result (
+                patient_id,
+                COALESCE(loinc_code, ''),
+                COALESCE(date, '')
+            )
+    """)
 
 
 def ensure_archive_registry(conn: sqlite3.Connection) -> None:

--- a/db/schema.py
+++ b/db/schema.py
@@ -1,7 +1,9 @@
 """Database schema helpers."""
 from __future__ import annotations
 
+import hashlib
 import sqlite3
+from datetime import datetime, timezone
 from textwrap import dedent
 from typing import Iterator
 
@@ -294,6 +296,7 @@ def ensure_data_source_columns(conn: sqlite3.Connection) -> None:
 
 def ensure_schema(conn: sqlite3.Connection) -> None:
     ensure_archive_registry(conn)
+    ensure_data_source_archive_reference(conn)
     ensure_provider_schema(conn)
     ensure_encounter_schema(conn)
     ensure_allergy_schema(conn)
@@ -346,6 +349,154 @@ def ensure_lab_constraints(conn: sqlite3.Connection) -> None:
                 COALESCE(date, '')
             )
     """)
+
+
+def ensure_data_source_archive_reference(conn: sqlite3.Connection) -> None:
+    """Ensure data_source.source_archive_id references ingested_archive."""
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(data_source)")
+    rows = cur.fetchall()
+    if not rows:
+        return
+    columns = {row[1]: row for row in rows}
+    archive_id_col = columns.get("source_archive_id")
+    if archive_id_col and (archive_id_col[2] or "").upper() == "INTEGER":
+        return
+    legacy_col = columns.get("source_archive")
+    if legacy_col is None:
+        return
+
+    fk_state = cur.execute("PRAGMA foreign_keys").fetchone()[0]
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.execute("ALTER TABLE data_source RENAME TO data_source__legacy")
+    conn.execute(
+        """
+        CREATE TABLE data_source (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            original_filename TEXT NOT NULL,
+            ingested_at TEXT NOT NULL,
+            file_sha256 TEXT NOT NULL,
+            source_archive_id INTEGER,
+            document_created TEXT,
+            repository_unique_id TEXT,
+            document_hash TEXT,
+            document_size INTEGER,
+            author_institution TEXT,
+            attachment_id INTEGER,
+            UNIQUE(file_sha256),
+            FOREIGN KEY(attachment_id) REFERENCES attachment(id),
+            FOREIGN KEY(source_archive_id) REFERENCES ingested_archive(id)
+        )
+        """
+    )
+
+    legacy_rows = conn.execute(
+        """
+        SELECT id,
+               original_filename,
+               ingested_at,
+               file_sha256,
+               source_archive,
+               document_created,
+               repository_unique_id,
+               document_hash,
+               document_size,
+               author_institution,
+               attachment_id
+          FROM data_source__legacy
+        """
+    ).fetchall()
+
+    archive_cache: dict[str, int] = {}
+    insert_sql = """
+        INSERT INTO data_source (
+            id,
+            original_filename,
+            ingested_at,
+            file_sha256,
+            source_archive_id,
+            document_created,
+            repository_unique_id,
+            document_hash,
+            document_size,
+            author_institution,
+            attachment_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+    for row in legacy_rows:
+        archive_name = row[4]
+        archive_id: int | None = None
+        if archive_name:
+            archive_id = archive_cache.get(archive_name)
+            if archive_id is None:
+                archive_id = _ensure_archive_entry(conn, archive_name, row[2])
+                archive_cache[archive_name] = archive_id
+        conn.execute(
+            insert_sql,
+            (
+                row[0],
+                row[1],
+                row[2],
+                row[3],
+                archive_id,
+                row[5],
+                row[6],
+                row[7],
+                row[8],
+                row[9],
+                row[10],
+            ),
+        )
+
+    conn.execute("DROP TABLE data_source__legacy")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_data_source_ingested_at ON data_source(ingested_at)"
+    )
+    conn.commit()
+    if fk_state:
+        conn.execute("PRAGMA foreign_keys = ON")
+
+
+def _ensure_archive_entry(
+    conn: sqlite3.Connection,
+    archive_name: str,
+    fallback_ingested_at: str | None,
+) -> int:
+    """Return archive id for legacy data_source rows, creating entries as needed."""
+    cur = conn.cursor()
+    row = cur.execute(
+        "SELECT id FROM ingested_archive WHERE archive_name = ? LIMIT 1",
+        (archive_name,),
+    ).fetchone()
+    if row:
+        return int(row[0])
+
+    if fallback_ingested_at and fallback_ingested_at.strip():
+        timestamp = fallback_ingested_at.strip()
+    else:
+        timestamp = (
+            datetime.now(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+    hash_source = f"legacy::{archive_name}::{timestamp}"
+    archive_hash = hashlib.sha256(hash_source.encode("utf-8")).hexdigest()
+    cur.execute(
+        """
+        INSERT INTO ingested_archive (
+            archive_name,
+            archive_sha256,
+            first_ingested_at,
+            last_ingested_at,
+            ingest_count
+        ) VALUES (?, ?, ?, ?, 1)
+        """,
+        (archive_name, archive_hash, timestamp, timestamp),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
 
 
 def ensure_archive_registry(conn: sqlite3.Connection) -> None:

--- a/db/schema.py
+++ b/db/schema.py
@@ -293,6 +293,7 @@ def ensure_data_source_columns(conn: sqlite3.Connection) -> None:
 
 
 def ensure_schema(conn: sqlite3.Connection) -> None:
+    ensure_archive_registry(conn)
     ensure_provider_schema(conn)
     ensure_encounter_schema(conn)
     ensure_allergy_schema(conn)
@@ -322,4 +323,22 @@ def ensure_immunization_constraints(conn: sqlite3.Connection) -> None:
                 COALESCE(cvx_code, '')
             )
         """)
+
+
+def ensure_archive_registry(conn: sqlite3.Connection) -> None:
+    """Ensure the ingested_archive registry table exists."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS ingested_archive (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            archive_name TEXT NOT NULL,
+            archive_sha256 TEXT NOT NULL UNIQUE,
+            first_ingested_at TEXT NOT NULL,
+            last_ingested_at TEXT NOT NULL,
+            ingest_count INTEGER NOT NULL DEFAULT 1
+        )
+    """)
+    conn.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_ingested_archive_hash
+            ON ingested_archive(archive_sha256)
+    """)
 

--- a/docs/AI_prompts.md
+++ b/docs/AI_prompts.md
@@ -481,3 +481,5 @@ In the upload_components.py code, I want you to add a function between validate 
 I think the ingestion is fairly rigorous against duplicating encounters if the zip file is uploaded more than once, but are there any other ways of handling the duplicate zip file other than incrementing by one? I don't want to reveal the possible names of other zip files, but I also don't want to have the person inadvertantly upload five copies of the same data.
 [2025-10-29 16:13:07 UTC]
 Refresh worked! Thanks for your patience - I'm still learning. OK. Now, let's focus on the content hash comparison with error message when a zip is attempted to be uploaded when it was handled before.
+[2025-10-29 16:32:34 UTC]
+We have a minor lab duplication issue to correct. Labs needs to be unique by date and LOINC. That isn't currently happening with the data. Let's fix that.

--- a/docs/AI_prompts.md
+++ b/docs/AI_prompts.md
@@ -455,3 +455,27 @@ Stuck?
 
 [2025-10-28 00:53:24 UTC]
 Last update - I want a box in the upper left-hand corner to provide the meaning of some of the shortened things.... PK = primary key; NN = not null; DEF = default; INT = integer
+[2025-10-29 15:20:37 UTC]
+Review AGENTS.md and log prompts to doc/AI_prompts.md. I want to work on the features for release 0.3.0. Let's start with uploading the zip file into the Streamlit app and having it run the ingest.py itself. Create a feature branch for this and let's begin.
+
+[2025-10-29 15:20:38 UTC]
+confirmed
+
+[2025-10-29 15:20:39 UTC]
+Sorry. docs/AI_prompts.md, not doc/AI_prompts.md.
+[2025-10-29 15:21:51 UTC]
+#19
+[2025-10-29 15:27:12 UTC]
+The way I picture this is that in the left-hand navigation area would be a button like "Upload records". That would take you to a window/screen where you could either drag & drop or click to select the appropriate zip files. We'll just focus on the zip file type for now. Then, after the zip file has been added, ingest.py is run on that file and the Streamlit instance is refreshed to now serve the updated information in addition to the old information.
+[2025-10-29 15:30:56 UTC]
+Go for it
+[2025-10-29 15:40:05 UTC]
+I ran the Streamlit package and can confirm the UI flow and UX is as expected. Next, you design test coverage around this new ingestion behavior. In the meantime, I'll examine any TODO items.
+[2025-10-29 15:48:53 UTC]
+I see the TODO(security) in the upload script. What does that indicate that I should do?
+[2025-10-29 15:55:50 UTC]
+What are some security ingestion triggers that need testing?
+[2025-10-29 16:04:29 UTC]
+In the upload_components.py code, I want you to add a function between validate archive size and archive path that validates it is a zip file. The streamlit file_uploader documentation says it is the dev's responsibility to confirm that the file type is appropriate, so we're not going to just rely on the file_uploader function.
+[2025-10-29 16:08:31 UTC]
+I think the ingestion is fairly rigorous against duplicating encounters if the zip file is uploaded more than once, but are there any other ways of handling the duplicate zip file other than incrementing by one? I don't want to reveal the possible names of other zip files, but I also don't want to have the person inadvertantly upload five copies of the same data.

--- a/docs/AI_prompts.md
+++ b/docs/AI_prompts.md
@@ -483,3 +483,6 @@ I think the ingestion is fairly rigorous against duplicating encounters if the z
 Refresh worked! Thanks for your patience - I'm still learning. OK. Now, let's focus on the content hash comparison with error message when a zip is attempted to be uploaded when it was handled before.
 [2025-10-29 16:32:34 UTC]
 We have a minor lab duplication issue to correct. Labs needs to be unique by date and LOINC. That isn't currently happening with the data. Let's fix that.
+[2025-10-29 17:36:57 UTC]
+Question about the ingested_archive table... if we have this strict non-duplication in place, why would we need a first ingested and last ingested and ingestion count?
+

--- a/docs/AI_prompts.md
+++ b/docs/AI_prompts.md
@@ -479,3 +479,5 @@ What are some security ingestion triggers that need testing?
 In the upload_components.py code, I want you to add a function between validate archive size and archive path that validates it is a zip file. The streamlit file_uploader documentation says it is the dev's responsibility to confirm that the file type is appropriate, so we're not going to just rely on the file_uploader function.
 [2025-10-29 16:08:31 UTC]
 I think the ingestion is fairly rigorous against duplicating encounters if the zip file is uploaded more than once, but are there any other ways of handling the duplicate zip file other than incrementing by one? I don't want to reveal the possible names of other zip files, but I also don't want to have the person inadvertantly upload five copies of the same data.
+[2025-10-29 16:13:07 UTC]
+Refresh worked! Thanks for your patience - I'm still learning. OK. Now, let's focus on the content hash comparison with error message when a zip is attempted to be uploaded when it was handled before.

--- a/docs/schema_changes.md
+++ b/docs/schema_changes.md
@@ -4,6 +4,7 @@
 
 - Introduced `ingested_archive` registry table to track archive SHA256 hashes, ingestion timestamps, and counts for duplicate detection (AI-assisted by Codex + Lauren).
 - Added supporting schema migration helpers to ensure the registry exists during database initialization.
+- Enforced `lab_result` uniqueness by patient, LOINC, and date with pre-index deduplication cleanup (AI-assisted by Codex + Lauren).
 
 ## 2025-10-19
 

--- a/docs/schema_changes.md
+++ b/docs/schema_changes.md
@@ -4,6 +4,7 @@
 
 - Introduced `ingested_archive` registry table to track archive SHA256 hashes, ingestion timestamps, and counts for duplicate detection (AI-assisted by Codex + Lauren).
 - Added supporting schema migration helpers to ensure the registry exists during database initialization.
+- Converted `data_source.source_archive` into a foreign key (`source_archive_id`) referencing `ingested_archive`, with migrations to backfill legacy rows (AI-assisted by Codex + Lauren).
 - Enforced `lab_result` uniqueness by patient, LOINC, and date with pre-index deduplication cleanup (AI-assisted by Codex + Lauren).
 
 ## 2025-10-19

--- a/docs/schema_changes.md
+++ b/docs/schema_changes.md
@@ -1,5 +1,10 @@
 # Schema Changes Log
 
+## 2025-10-29
+
+- Introduced `ingested_archive` registry table to track archive SHA256 hashes, ingestion timestamps, and counts for duplicate detection (AI-assisted by Codex + Lauren).
+- Added supporting schema migration helpers to ensure the registry exists during database initialization.
+
 ## 2025-10-19
 
 - Expanded the `allergy` table with provider and encounter foreign keys, coded substance and reaction metadata, onset/noted timestamps, source identifiers, and supporting indexes to minimise duplicates (AI-assisted by Codex + Lauren).

--- a/frontend/db_utils.py
+++ b/frontend/db_utils.py
@@ -168,18 +168,22 @@ def get_encounter_detail(conn, encounter_id):
                p.family_name AS provider_family_name,
                ds.id AS data_source_id,
                ds.original_filename,
-               ds.source_archive,
+               ds.source_archive_id,
                ds.document_created,
                ds.repository_unique_id,
                ds.document_hash,
                ds.document_size,
                ds.author_institution,
                ds.attachment_id,
+               ia.archive_name AS source_archive,
+               ia.ingest_count AS source_archive_ingest_count,
+               ia.last_ingested_at AS source_archive_last_ingested_at,
                a.file_path AS attachment_path,
                a.mime_type AS attachment_mime_type
           FROM encounter e
           LEFT JOIN provider p ON e.provider_id = p.id
           LEFT JOIN data_source ds ON e.data_source_id = ds.id
+          LEFT JOIN ingested_archive ia ON ds.source_archive_id = ia.id
           LEFT JOIN attachment a ON ds.attachment_id = a.id
          WHERE e.id = ?
         """
@@ -206,7 +210,10 @@ def get_encounter_detail(conn, encounter_id):
         "data_source": {
             "id": meta_row.get("data_source_id"),
             "original_filename": meta_row.get("original_filename"),
+            "source_archive_id": meta_row.get("source_archive_id"),
             "source_archive": meta_row.get("source_archive"),
+            "source_archive_ingest_count": meta_row.get("source_archive_ingest_count"),
+            "source_archive_last_ingested_at": meta_row.get("source_archive_last_ingested_at"),
             "document_created": meta_row.get("document_created"),
             "repository_unique_id": meta_row.get("repository_unique_id"),
             "document_hash": meta_row.get("document_hash"),

--- a/frontend/upload_components.py
+++ b/frontend/upload_components.py
@@ -3,25 +3,27 @@
 # Date: 2025-10-29
 # Reviewed by: Lauren
 # Review date: 2025-10-29
-# Tests: Manual Streamlit verification;
+# Tests: Manual Streamlit verification; tests/test_upload_components.py
 # AI-assisted: Portions of this module were generated with AI assistance.
 """Streamlit components enabling ZIP uploads that invoke the ingestion pipeline."""
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import re
 import shutil
 import sqlite3
 import unicodedata
 from pathlib import Path
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import streamlit as st
 from streamlit.runtime.uploaded_file_manager import UploadedFile
 import zipfile
 
 from ingest import ingest_archive
+from services.archives import archive_was_ingested
 
 logger = logging.getLogger(__name__)
 
@@ -70,8 +72,24 @@ def render_upload_page(
             try:
                 _validate_archive_size(archive.size, archive.name)
                 _validate_archive_type(archive)
+                archive_hash = _compute_uploaded_hash(archive)
+                prior_ingest = archive_was_ingested(conn, archive_hash)
+                if prior_ingest:
+                    errors.append(
+                        _format_duplicate_message(archive.name, prior_ingest)
+                    )
+                    logger.info(
+                        "Skipped duplicate archive %s (hash %s).",
+                        archive.name,
+                        archive_hash,
+                    )
+                    continue
                 archive_path = _persist_archive(archive, RAW_ARCHIVE_DIR)
-                ingest_archive(conn, archive_path)
+                ingest_archive(
+                    conn,
+                    archive_path,
+                    archive_sha256=archive_hash,
+                )
                 successes.append(f"Ingested {archive_path.name}")
             except ValueError as exc:
                 errors.append(str(exc))
@@ -111,6 +129,34 @@ def _validate_archive_type(archive: UploadedFile) -> None:
         raise ValueError(f"{archive.name} is not a valid ZIP archive.") from exc
     finally:
         archive.seek(0)
+
+
+def _compute_uploaded_hash(archive: UploadedFile) -> str:
+    """Return SHA-256 hash for an uploaded archive stream."""
+    hasher = hashlib.sha256()
+    archive.seek(0)
+    for chunk in iter(lambda: archive.read(8192), b""):
+        if not chunk:
+            break
+        hasher.update(chunk)
+    archive.seek(0)
+    return hasher.hexdigest()
+
+
+def _format_duplicate_message(
+    filename: str,
+    registry_row: Dict[str, object],
+) -> str:
+    """Compose a human-readable duplicate notice."""
+    last_ingested = registry_row.get("last_ingested_at") or registry_row.get(
+        "first_ingested_at"
+    )
+    count = registry_row.get("ingest_count")
+    suffix = ""
+    if isinstance(count, int) and count > 1:
+        suffix = f" ({count} previous ingests)"
+    timestamp = last_ingested or "a prior run"
+    return f"{filename} was previously ingested on {timestamp}{suffix} and was skipped."
 
 
 def _persist_archive(archive: UploadedFile, destination: Path) -> Path:

--- a/frontend/upload_components.py
+++ b/frontend/upload_components.py
@@ -1,0 +1,153 @@
+# Purpose: Streamlit workflow for secure ZIP uploads and ingestion triggers.
+# Author: Codex + Lauren
+# Date: 2025-10-29
+# Reviewed by: Lauren
+# Review date: 2025-10-29
+# Tests: Manual Streamlit verification;
+# AI-assisted: Portions of this module were generated with AI assistance.
+"""Streamlit components enabling ZIP uploads that invoke the ingestion pipeline."""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import sqlite3
+import unicodedata
+from pathlib import Path
+from typing import Callable, List, Optional
+
+import streamlit as st
+from streamlit.runtime.uploaded_file_manager import UploadedFile
+import zipfile
+
+from ingest import ingest_archive
+
+logger = logging.getLogger(__name__)
+
+RAW_ARCHIVE_DIR = Path("data/raw")
+MAX_ARCHIVE_BYTES = 250 * 1024 * 1024  # 250 MB ceiling to discourage large uploads.
+
+
+def render_upload_page(
+    conn: sqlite3.Connection,
+    *,
+    rerun_callback: Optional[Callable[[], None]] = None,
+) -> None:
+    """Render the upload page and invoke ingestion when requested."""
+    st.header("Upload CCD Archives")
+    st.caption(
+        "Add ZIP files containing CCD documents. "
+        "Uploaded archives are ingested immediately."
+    )
+
+    with st.form("zip-upload-form"):
+        uploaded_archives = st.file_uploader(
+            "Select CCD ZIP archives",
+            type=["zip"],
+            accept_multiple_files=True,
+            help=(
+                "Only ZIP files are accepted. "
+                "Archives are written to data/raw/ and ingested."
+            ),
+        )
+        trigger_ingest = st.form_submit_button("Upload and ingest")
+
+    if not trigger_ingest:
+        return
+
+    if not uploaded_archives:
+        st.warning("No ZIP archives selected.")
+        return
+
+    RAW_ARCHIVE_DIR.mkdir(parents=True, exist_ok=True)
+
+    successes: List[str] = []
+    errors: List[str] = []
+
+    with st.spinner("Ingesting uploaded archives..."):
+        for archive in uploaded_archives:
+            try:
+                _validate_archive_size(archive.size, archive.name)
+                _validate_archive_type(archive)
+                archive_path = _persist_archive(archive, RAW_ARCHIVE_DIR)
+                ingest_archive(conn, archive_path)
+                successes.append(f"Ingested {archive_path.name}")
+            except ValueError as exc:
+                errors.append(str(exc))
+                logger.warning("Validation failed for %s: %s", archive.name, exc)
+            except Exception as exc:  # pragma: no cover - defensive
+                errors.append(f"Ingestion failed for {archive.name}: {exc}")
+                logger.exception("Unexpected error during ingestion for %s", archive.name)
+
+    st.session_state["upload_feedback"] = {
+        "success": successes,
+        "errors": errors,
+    }
+
+    if rerun_callback:
+        rerun_callback()
+
+
+def _validate_archive_size(size_bytes: Optional[int], label: str) -> None:
+    """Ensure archives are within acceptable bounds for ingestion."""
+    if size_bytes is None:
+        return
+    if size_bytes > MAX_ARCHIVE_BYTES:
+        raise ValueError(
+            f"{label} is larger than the {MAX_ARCHIVE_BYTES // (1024 * 1024)} MB limit."
+        )
+
+
+def _validate_archive_type(archive: UploadedFile) -> None:
+    """Confirm the uploaded file is a ZIP archive."""
+    if not archive:
+        raise ValueError("Missing archive payload.")
+    try:
+        archive.seek(0)
+        with zipfile.ZipFile(archive) as candidate:
+            candidate.namelist()
+    except (zipfile.BadZipFile, zipfile.LargeZipFile, OSError, RuntimeError) as exc:
+        raise ValueError(f"{archive.name} is not a valid ZIP archive.") from exc
+    finally:
+        archive.seek(0)
+
+
+def _persist_archive(archive: UploadedFile, destination: Path) -> Path:
+    """Write the uploaded archive to disk with a sanitised, unique filename."""
+    sanitized_name = _sanitize_filename(archive.name or "ccd_archive.zip")
+    target_path = _deduplicate_name(destination, sanitized_name)
+
+    archive.seek(0)
+    with target_path.open("wb") as buffer:
+        shutil.copyfileobj(archive, buffer)
+
+    return target_path
+
+
+def _sanitize_filename(candidate: str) -> str:
+    """Return a filesystem-safe filename while keeping contextual cues."""
+    base = Path(candidate).name
+    normalized = unicodedata.normalize("NFKD", base)
+    ascii_only = normalized.encode("ascii", "ignore").decode("ascii")
+    ascii_only = ascii_only.replace(" ", "_")
+    cleaned = re.sub(r"[^A-Za-z0-9._-]", "_", ascii_only)
+    if not cleaned.lower().endswith(".zip"):
+        cleaned = f"{cleaned}.zip"
+    return cleaned or "ccd_archive.zip"
+
+
+def _deduplicate_name(directory: Path, filename: str) -> Path:
+    """Prevent overwriting by appending a counter when collisions occur."""
+    candidate = directory / filename
+    if not candidate.exists():
+        return candidate
+
+    stem = candidate.stem
+    suffix = candidate.suffix
+    counter = 1
+    while True:
+        proposal = directory / f"{stem}_{counter}{suffix}"
+        if not proposal.exists():
+            return proposal
+        counter += 1

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -21,6 +21,7 @@ from . import xml_utils
 from .note_components import render_progress_notes
 from .schema_components import render_schema_documentation
 from .trend_components import render_patient_trends
+from .upload_components import render_upload_page
 
 
 def _ensure_state() -> None:
@@ -31,6 +32,7 @@ def _ensure_state() -> None:
     state.setdefault("selected_patient_id", None)
     state.setdefault("selected_patient_label", None)
     state.setdefault("selected_encounter_id", None)
+    state.setdefault("upload_feedback", None)
     if "_rerun_fn" not in state:
         rerun_fn = getattr(st, "experimental_rerun", None) or getattr(st, "rerun", None)
         state["_rerun_fn"] = rerun_fn
@@ -61,6 +63,9 @@ def render_patient_encounter_experience(conn) -> bool:
         return False
     if state["app_view"] == "schema":
         _show_schema_documentation()
+        return False
+    if state["app_view"] == "upload":
+        _show_upload_page(conn)
         return False
     _show_encounter_overview(conn)
     return True
@@ -104,6 +109,7 @@ def _navigation_controls() -> str:
         ("Encounter overview", "overview"),
         ("Patient trends", "trends"),
         ("Database schema", "schema"),
+        ("Upload records", "upload"),
     ]
     labels = [label for label, _ in options]
     nav_view = state.get("nav_view", "overview")
@@ -121,6 +127,19 @@ def _navigation_controls() -> str:
     if selected_view != state.get("nav_view"):
         state["nav_view"] = selected_view
     return state["nav_view"]
+
+
+def _show_upload_page(conn: sqlite3.Connection) -> None:
+    """Render the upload workflow and surface latest status messaging."""
+    state = st.session_state
+    feedback = state.get("upload_feedback")
+    if isinstance(feedback, dict):
+        for message in feedback.get("success", []):
+            st.success(message)
+        for message in feedback.get("errors", []):
+            st.error(message)
+        state["upload_feedback"] = None
+    render_upload_page(conn, rerun_callback=_rerun)
 
 
 def _select_patient(

--- a/ingest.py
+++ b/ingest.py
@@ -249,21 +249,29 @@ def ingest_archive(
     metadata_lookup = _load_metadata(destination)
 
     try:
-        _ingest_documents_from_archive(
+        data_source_ids = _ingest_documents_from_archive(
             conn,
             archive_path,
             destination,
             metadata_lookup,
+            archive_name=archive_path.name,
         )
     except Exception:
         logger.exception("Ingestion failed for archive %s.", archive_path.name)
         raise
 
-    register_ingested_archive(conn, archive_path.name, archive_sha256)
+    archive_id = register_ingested_archive(conn, archive_path.name, archive_sha256)
+    if data_source_ids:
+        conn.executemany(
+            "UPDATE data_source SET source_archive_id = ? WHERE id = ?",
+            [(archive_id, ds_id) for ds_id in data_source_ids],
+        )
+        conn.commit()
     logger.debug(
-        "Registered archive %s with hash %s.",
+        "Registered archive %s with hash %s (id=%s).",
         archive_path.name,
         archive_sha256,
+        archive_id,
     )
 
 
@@ -283,8 +291,11 @@ def _ingest_documents_from_archive(
     archive_path: Path,
     destination: Path,
     metadata_lookup: dict[str, dict[str, Any]],
-) -> None:
+    *,
+    archive_name: str,
+) -> list[int]:
     """Process all CCD documents within a prepared archive directory."""
+    data_source_ids: set[int] = set()
     for xml_file in destination.rglob("*.xml"):
         if xml_file.name.lower() == "metadata.xml":
             logger.debug("Skipping metadata descriptor %s.", xml_file)
@@ -309,9 +320,9 @@ def _ingest_documents_from_archive(
             data_source_id = upsert_data_source(
                 conn,
                 xml_file,
-                source_archive=archive_path.name,
                 metadata=metadata_lookup.get(meta_key),
             )
+            data_source_ids.add(data_source_id)
         except (OSError, sqlite3.DatabaseError) as exc:
             logger.warning(
                 "Skipping %s due to provenance capture error: %s",
@@ -322,7 +333,7 @@ def _ingest_documents_from_archive(
 
         record_metadata = {
             "data_source_id": data_source_id,
-            "source_archive": archive_path.name,
+            "source_archive": archive_name,
             "source_document": xml_file.name,
         }
         patient_record = {**patient_data, **record_metadata}
@@ -402,6 +413,7 @@ def _ingest_documents_from_archive(
             given,
             family,
         )
+    return list(data_source_ids)
 
 def _load_metadata(root: Path) -> dict[str, dict[str, Any]]:
     """Return a mapping of document path -> metadata extracted from METADATA.XML."""

--- a/ingest.py
+++ b/ingest.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 """Main ingestion workflow for CCD archives."""
 
 import argparse
+import hashlib
 import logging
 import mimetypes
 import sqlite3
@@ -35,6 +36,7 @@ from parsers import (
     parse_vitals,
 )
 from services.allergies import insert_allergies
+from services.archives import archive_was_ingested, register_ingested_archive
 from services.attachments import upsert_attachment
 from services.common import clean_str
 from services.conditions import insert_conditions
@@ -213,18 +215,76 @@ def parse_ccd(xml_file: Path) -> ParsedCCD:
     }
 
 
-def ingest_archive(conn: sqlite3.Connection, archive_path: Path) -> None:
+def ingest_archive(
+    conn: sqlite3.Connection,
+    archive_path: Path,
+    *,
+    archive_sha256: Optional[str] = None,
+) -> None:
     """Ingest a single CCD archive into the database.
 
     Args:
         conn: Open SQLite connection.
         archive_path: ZIP archive to ingest.
     """
+    if archive_sha256 is None:
+        try:
+            archive_sha256 = _compute_archive_sha256(archive_path)
+        except OSError as exc:
+            logger.warning("Unable to hash %s: %s", archive_path, exc)
+            return
+
+    existing_archive = archive_was_ingested(conn, archive_sha256)
+    if existing_archive:
+        logger.info(
+            "Skipping %s; previously ingested on %s.",
+            archive_path.name,
+            existing_archive.get("last_ingested_at") or existing_archive.get("first_ingested_at"),
+        )
+        return
+
     destination = PARSED_DIR / archive_path.stem
     unzip_raw_files(archive_path, destination)
 
     metadata_lookup = _load_metadata(destination)
 
+    try:
+        _ingest_documents_from_archive(
+            conn,
+            archive_path,
+            destination,
+            metadata_lookup,
+        )
+    except Exception:
+        logger.exception("Ingestion failed for archive %s.", archive_path.name)
+        raise
+
+    register_ingested_archive(conn, archive_path.name, archive_sha256)
+    logger.debug(
+        "Registered archive %s with hash %s.",
+        archive_path.name,
+        archive_sha256,
+    )
+
+
+def _compute_archive_sha256(archive_path: Path) -> str:
+    """Return the SHA-256 hash for the provided archive path."""
+    hasher = hashlib.sha256()
+    with archive_path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            if not chunk:
+                break
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _ingest_documents_from_archive(
+    conn: sqlite3.Connection,
+    archive_path: Path,
+    destination: Path,
+    metadata_lookup: dict[str, dict[str, Any]],
+) -> None:
+    """Process all CCD documents within a prepared archive directory."""
     for xml_file in destination.rglob("*.xml"):
         if xml_file.name.lower() == "metadata.xml":
             logger.debug("Skipping metadata descriptor %s.", xml_file)
@@ -342,7 +402,6 @@ def ingest_archive(conn: sqlite3.Connection, archive_path: Path) -> None:
             given,
             family,
         )
-
 
 def _load_metadata(root: Path) -> dict[str, dict[str, Any]]:
     """Return a mapping of document path -> metadata extracted from METADATA.XML."""

--- a/schema.sql
+++ b/schema.sql
@@ -22,6 +22,18 @@ CREATE TABLE IF NOT EXISTS data_source (
 
 CREATE INDEX IF NOT EXISTS idx_data_source_ingested_at ON data_source(ingested_at);
 
+CREATE TABLE IF NOT EXISTS ingested_archive (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    archive_name TEXT NOT NULL,
+    archive_sha256 TEXT NOT NULL UNIQUE,
+    first_ingested_at TEXT NOT NULL,
+    last_ingested_at TEXT NOT NULL,
+    ingest_count INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ingested_archive_hash
+    ON ingested_archive(archive_sha256);
+
 -- =====================
 -- Core Patient Table
 -- =====================

--- a/schema.sql
+++ b/schema.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS data_source (
     original_filename TEXT NOT NULL,
     ingested_at TEXT NOT NULL,
     file_sha256 TEXT NOT NULL,
-    source_archive TEXT,
+    source_archive_id INTEGER,
     document_created TEXT,
     repository_unique_id TEXT,
     document_hash TEXT,
@@ -17,7 +17,8 @@ CREATE TABLE IF NOT EXISTS data_source (
     author_institution TEXT,
     attachment_id INTEGER,
     UNIQUE(file_sha256),
-    FOREIGN KEY(attachment_id) REFERENCES attachment(id)
+    FOREIGN KEY(attachment_id) REFERENCES attachment(id),
+    FOREIGN KEY(source_archive_id) REFERENCES ingested_archive(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_data_source_ingested_at ON data_source(ingested_at);

--- a/services/archives.py
+++ b/services/archives.py
@@ -1,0 +1,98 @@
+# Purpose: Manage content-hash registry for ingested archives.
+# Author: Codex + Lauren
+# Date: 2025-10-29
+# Tests: tests/test_archives_service.py
+# AI-assisted: Portions of this module were generated with AI assistance.
+"""Helpers for tracking previously ingested CCD archives."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import sqlite3
+
+__all__ = ["archive_was_ingested", "register_ingested_archive"]
+
+
+def archive_was_ingested(
+    conn: sqlite3.Connection,
+    archive_sha256: str,
+) -> Optional[Dict[str, Any]]:
+    """Return registry details when an archive hash already exists."""
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT id,
+               archive_name,
+               archive_sha256,
+               first_ingested_at,
+               last_ingested_at,
+               ingest_count
+          FROM ingested_archive
+         WHERE archive_sha256 = ?
+        """,
+        (archive_sha256,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    keys = [
+        "id",
+        "archive_name",
+        "archive_sha256",
+        "first_ingested_at",
+        "last_ingested_at",
+        "ingest_count",
+    ]
+    return dict(zip(keys, row))
+
+
+def register_ingested_archive(
+    conn: sqlite3.Connection,
+    archive_name: str,
+    archive_sha256: str,
+) -> None:
+    """Record or update the registry entry for an ingested archive."""
+    timestamp = (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT ingest_count
+          FROM ingested_archive
+         WHERE archive_sha256 = ?
+        """,
+        (archive_sha256,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        cur.execute(
+            """
+            INSERT INTO ingested_archive (
+                archive_name,
+                archive_sha256,
+                first_ingested_at,
+                last_ingested_at,
+                ingest_count
+            ) VALUES (?, ?, ?, ?, 1)
+            """,
+            (archive_name, archive_sha256, timestamp, timestamp),
+        )
+    else:
+        cur.execute(
+            """
+            UPDATE ingested_archive
+               SET archive_name = ?,
+                   last_ingested_at = ?,
+                   ingest_count = ingest_count + 1
+             WHERE archive_sha256 = ?
+            """,
+            (archive_name, timestamp, archive_sha256),
+        )
+    conn.commit()

--- a/services/archives.py
+++ b/services/archives.py
@@ -52,7 +52,7 @@ def register_ingested_archive(
     conn: sqlite3.Connection,
     archive_name: str,
     archive_sha256: str,
-) -> None:
+) -> int:
     """Record or update the registry entry for an ingested archive."""
     timestamp = (
         datetime.now(timezone.utc)
@@ -64,7 +64,7 @@ def register_ingested_archive(
     cur = conn.cursor()
     cur.execute(
         """
-        SELECT ingest_count
+        SELECT id, ingest_count
           FROM ingested_archive
          WHERE archive_sha256 = ?
         """,
@@ -84,7 +84,9 @@ def register_ingested_archive(
             """,
             (archive_name, archive_sha256, timestamp, timestamp),
         )
+        archive_id = int(cur.lastrowid)
     else:
+        archive_id = int(row[0])
         cur.execute(
             """
             UPDATE ingested_archive
@@ -96,3 +98,4 @@ def register_ingested_archive(
             (archive_name, timestamp, archive_sha256),
         )
     conn.commit()
+    return archive_id

--- a/services/data_sources.py
+++ b/services/data_sources.py
@@ -23,7 +23,7 @@ def upsert_data_source(
     conn: sqlite3.Connection,
     file_path: Path,
     *,
-    source_archive: Optional[str] = None,
+    archive_id: Optional[int] = None,
     metadata: Optional[dict[str, object]] = None,
 ) -> int:
     """Ensure provenance metadata exists for an ingested CCD artifact.
@@ -31,7 +31,7 @@ def upsert_data_source(
     Args:
         conn: Active SQLite connection with foreign keys enabled.
         file_path: Path to the CCD XML file being persisted.
-        source_archive: Optional archive name that contained the CCD file.
+        archive_id: Optional ingested_archive primary key for the containing archive.
 
     Returns:
         int: The primary key of the corresponding `data_source` row.
@@ -54,7 +54,7 @@ def upsert_data_source(
         .replace("+00:00", "Z")
     )
 
-    curated_archive = source_archive or None
+    curated_archive_id = int(archive_id) if archive_id is not None else None
     metadata = metadata or {}
     document_created = metadata.get("document_created")
     repository_unique_id = metadata.get("repository_unique_id")
@@ -90,7 +90,7 @@ def upsert_data_source(
             original_filename,
             ingested_at,
             file_sha256,
-            source_archive,
+            source_archive_id,
             document_created,
             repository_unique_id,
             document_hash,
@@ -100,7 +100,7 @@ def upsert_data_source(
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(file_sha256) DO UPDATE SET
             original_filename = excluded.original_filename,
-            source_archive = COALESCE(excluded.source_archive, data_source.source_archive),
+            source_archive_id = COALESCE(excluded.source_archive_id, data_source.source_archive_id),
             document_created = COALESCE(excluded.document_created, data_source.document_created),
             repository_unique_id = COALESCE(excluded.repository_unique_id, data_source.repository_unique_id),
             document_hash = COALESCE(excluded.document_hash, data_source.document_hash),
@@ -112,7 +112,7 @@ def upsert_data_source(
             file_path.name,
             ingested_at,
             file_sha256,
-            curated_archive,
+            curated_archive_id,
             document_created_text,
             repository_unique_id_text,
             document_hash_text,

--- a/services/labs.py
+++ b/services/labs.py
@@ -93,29 +93,28 @@ def insert_labs(
 
     normalized_labs = [dict(lab) for lab in labs]
 
-    def _key(date_value: Any, encounter_value: Any, loinc_value: Any) -> tuple[Any, Any, Any]:
+    def _key(date_value: Any, loinc_value: Any) -> tuple[Any, Any]:
         return (
             clean_str(date_value),
-            coerce_int(encounter_value),
             clean_str(loinc_value),
         )
 
     existing_keys_query = """
-        SELECT date, encounter_id, loinc_code
+        SELECT date, loinc_code
           FROM lab_result
          WHERE patient_id = ?
     """
     existing_keys = {
-        _key(row[0], row[1], row[2])
+        _key(row[0], row[1])
         for row in conn.execute(existing_keys_query, (patient_id,))
     }
 
     rows_to_insert: list[Tuple[Any, ...]] = []
-    pending_keys: set[tuple[Any, Any, Any]] = set()
+    pending_keys: set[tuple[Any, Any]] = set()
 
     for lab_entry in normalized_labs:
         row = build_row(lab_entry)
-        unique_key = _key(row[8], row[1], row[2])
+        unique_key = _key(row[8], row[2])
         if unique_key in existing_keys or unique_key in pending_keys:
             continue
         pending_keys.add(unique_key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import hashlib
 import sqlite3
 from pathlib import Path
 from typing import Iterator
@@ -25,16 +26,30 @@ def schema_conn() -> Iterator[sqlite3.Connection]:
 def data_source_id(schema_conn: sqlite3.Connection) -> int:
     """Insert a reusable data_source row for tests that need a valid foreign key."""
     cursor = schema_conn.cursor()
+    archive_hash = hashlib.sha256(b"archive.zip").hexdigest()
+    cursor.execute(
+        """
+        INSERT INTO ingested_archive (
+            archive_name,
+            archive_sha256,
+            first_ingested_at,
+            last_ingested_at,
+            ingest_count
+        ) VALUES (?, ?, '2025-10-12T00:00:00Z', '2025-10-12T00:00:00Z', 1)
+        """,
+        ("archive.zip", archive_hash),
+    )
+    archive_id = int(cursor.lastrowid)
     cursor.execute(
         """
         INSERT INTO data_source (
             original_filename,
             ingested_at,
             file_sha256,
-            source_archive
+            source_archive_id
         ) VALUES (?, ?, ?, ?)
         """,
-        ("sample.xml", "2025-10-12T00:00:00Z", "hash-sample", "archive.zip"),
+        ("sample.xml", "2025-10-12T00:00:00Z", "hash-sample", archive_id),
     )
     schema_conn.commit()
     return int(cursor.lastrowid)

--- a/tests/test_archives_service.py
+++ b/tests/test_archives_service.py
@@ -16,10 +16,11 @@ from services import archives
 def test_archive_registration_inserts_new_row(schema_conn: sqlite3.Connection) -> None:
     """First registration should create a new row with count = 1."""
     archive_hash = "abc123"
-    archives.register_ingested_archive(schema_conn, "first.zip", archive_hash)
+    archive_id = archives.register_ingested_archive(schema_conn, "first.zip", archive_hash)
 
     row = archives.archive_was_ingested(schema_conn, archive_hash)
     assert row is not None
+    assert row["id"] == archive_id
     assert row["archive_name"] == "first.zip"
     assert row["archive_sha256"] == archive_hash
     assert row["ingest_count"] == 1
@@ -29,13 +30,14 @@ def test_archive_registration_inserts_new_row(schema_conn: sqlite3.Connection) -
 def test_archive_registration_updates_existing(schema_conn: sqlite3.Connection) -> None:
     """Repeated registration should increment count and update timestamps."""
     archive_hash = "def456"
-    archives.register_ingested_archive(schema_conn, "initial.zip", archive_hash)
+    first_id = archives.register_ingested_archive(schema_conn, "initial.zip", archive_hash)
     first_row = archives.archive_was_ingested(schema_conn, archive_hash)
     assert first_row is not None
-    archives.register_ingested_archive(schema_conn, "updated-name.zip", archive_hash)
+    second_id = archives.register_ingested_archive(schema_conn, "updated-name.zip", archive_hash)
 
     second_row = archives.archive_was_ingested(schema_conn, archive_hash)
     assert second_row is not None
+    assert first_id == second_id == second_row["id"]
     assert second_row["archive_name"] == "updated-name.zip"
     assert second_row["ingest_count"] == 2
     assert second_row["first_ingested_at"] <= second_row["last_ingested_at"]

--- a/tests/test_archives_service.py
+++ b/tests/test_archives_service.py
@@ -1,0 +1,41 @@
+# Purpose: Validate archive registry helpers for ingestion deduplication.
+# Author: Codex + Lauren
+# Date: 2025-10-29
+# Tests: tests/test_archives_service.py
+# AI-assisted: This test module was generated with AI assistance.
+"""Tests for services.archives module."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Dict
+
+from services import archives
+
+
+def test_archive_registration_inserts_new_row(schema_conn: sqlite3.Connection) -> None:
+    """First registration should create a new row with count = 1."""
+    archive_hash = "abc123"
+    archives.register_ingested_archive(schema_conn, "first.zip", archive_hash)
+
+    row = archives.archive_was_ingested(schema_conn, archive_hash)
+    assert row is not None
+    assert row["archive_name"] == "first.zip"
+    assert row["archive_sha256"] == archive_hash
+    assert row["ingest_count"] == 1
+    assert row["first_ingested_at"] == row["last_ingested_at"]
+
+
+def test_archive_registration_updates_existing(schema_conn: sqlite3.Connection) -> None:
+    """Repeated registration should increment count and update timestamps."""
+    archive_hash = "def456"
+    archives.register_ingested_archive(schema_conn, "initial.zip", archive_hash)
+    first_row = archives.archive_was_ingested(schema_conn, archive_hash)
+    assert first_row is not None
+    archives.register_ingested_archive(schema_conn, "updated-name.zip", archive_hash)
+
+    second_row = archives.archive_was_ingested(schema_conn, archive_hash)
+    assert second_row is not None
+    assert second_row["archive_name"] == "updated-name.zip"
+    assert second_row["ingest_count"] == 2
+    assert second_row["first_ingested_at"] <= second_row["last_ingested_at"]

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import sqlite3
 from pathlib import Path
 
@@ -7,16 +8,42 @@ import pytest
 
 from services.data_sources import link_attachment, upsert_data_source
 
+def _create_archive(conn: sqlite3.Connection, name: str) -> int:
+    hash_value = hashlib.sha256(name.encode("utf-8")).hexdigest()
+    conn.execute(
+        """
+        INSERT INTO ingested_archive (
+            archive_name,
+            archive_sha256,
+            first_ingested_at,
+            last_ingested_at,
+            ingest_count
+        ) VALUES (?, ?, '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z', 1)
+        """,
+        (name, hash_value),
+    )
+    archive_id = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+    conn.commit()
+    return archive_id
+
 
 def _assert_single_row(conn: sqlite3.Connection, expected_archive: str) -> None:
     row = conn.execute(
-        "SELECT original_filename, source_archive, ingested_at FROM data_source"
+        """
+        SELECT ds.original_filename,
+               ia.archive_name,
+               ds.ingested_at,
+               ds.source_archive_id
+          FROM data_source ds
+          LEFT JOIN ingested_archive ia ON ds.source_archive_id = ia.id
+        """
     ).fetchone()
     assert row is not None
-    filename, archive, ingested_at = row
+    filename, archive, ingested_at, archive_id = row
     assert filename == "document.xml"
     assert archive == expected_archive
     assert ingested_at.endswith("Z")
+    assert archive_id is not None
 
 
 def test_upsert_data_source_inserts_and_updates(
@@ -25,14 +52,16 @@ def test_upsert_data_source_inserts_and_updates(
     doc_path = tmp_path / "document.xml"
     doc_path.write_text("test payload", encoding="utf-8")
 
+    archive_id_1 = _create_archive(schema_conn, "batch-01.zip")
     first_id = upsert_data_source(
-        schema_conn, doc_path, source_archive="batch-01.zip"
+        schema_conn, doc_path, archive_id=archive_id_1
     )
     assert isinstance(first_id, int) and first_id > 0
     _assert_single_row(schema_conn, "batch-01.zip")
 
+    archive_id_2 = _create_archive(schema_conn, "batch-02.zip")
     second_id = upsert_data_source(
-        schema_conn, doc_path, source_archive="batch-02.zip"
+        schema_conn, doc_path, archive_id=archive_id_2
     )
     assert second_id == first_id
     _assert_single_row(schema_conn, "batch-02.zip")
@@ -46,8 +75,9 @@ def test_upsert_data_source_creates_unique_rows(
     doc_b = tmp_path / "b.xml"
     doc_b.write_text("content-b", encoding="utf-8")
 
-    id_a = upsert_data_source(schema_conn, doc_a, source_archive="archive.zip")
-    id_b = upsert_data_source(schema_conn, doc_b, source_archive="archive.zip")
+    archive_id = _create_archive(schema_conn, "archive.zip")
+    id_a = upsert_data_source(schema_conn, doc_a, archive_id=archive_id)
+    id_b = upsert_data_source(schema_conn, doc_b, archive_id=archive_id)
 
     assert id_a != id_b
     count = schema_conn.execute(
@@ -78,10 +108,12 @@ def test_upsert_data_source_applies_metadata(
         "author_institution": "Unit Test Clinic",
     }
 
+    archive_id = _create_archive(schema_conn, "archive.zip")
+
     upsert_data_source(
         schema_conn,
         doc_path,
-        source_archive="archive.zip",
+        archive_id=archive_id,
         metadata=metadata,
     )
 
@@ -110,8 +142,9 @@ def test_link_attachment_updates_data_source(
 ) -> None:
     doc_path = tmp_path / "link.xml"
     doc_path.write_text("link", encoding="utf-8")
+    archive_id = _create_archive(schema_conn, "archive.zip")
     data_source_id = upsert_data_source(
-        schema_conn, doc_path, source_archive="archive.zip"
+        schema_conn, doc_path, archive_id=archive_id
     )
 
     schema_conn.execute(

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -92,23 +92,28 @@ def test_ingest_archive_records_data_source(
     ds_row = schema_conn.execute(
         """
         SELECT
-            id,
-            original_filename,
-            source_archive,
-            document_created,
-            repository_unique_id,
-            document_hash,
-            document_size,
-            author_institution,
-            attachment_id
-          FROM data_source
+            ds.id,
+            ds.original_filename,
+            ds.source_archive_id,
+            ia.archive_name,
+            ia.ingest_count,
+            ds.document_created,
+            ds.repository_unique_id,
+            ds.document_hash,
+            ds.document_size,
+            ds.author_institution,
+            ds.attachment_id
+          FROM data_source ds
+          LEFT JOIN ingested_archive ia ON ds.source_archive_id = ia.id
         """
     ).fetchone()
     assert ds_row is not None
     (
         data_source_id,
         original_filename,
-        source_archive,
+        source_archive_id,
+        source_archive_name,
+        source_archive_ingest_count,
         document_created,
         repository_unique_id,
         document_hash,
@@ -117,7 +122,9 @@ def test_ingest_archive_records_data_source(
         ds_attachment_id,
     ) = ds_row
     assert original_filename == "DOC0001.XML"
-    assert source_archive == "sample.zip"
+    assert source_archive_name == "sample.zip"
+    assert source_archive_id is not None
+    assert source_archive_ingest_count == 1
     assert document_created == "2025-01-01T12:34:56Z"
     assert repository_unique_id == "urn:repository:123"
     assert document_hash == "abc123hash"
@@ -155,16 +162,17 @@ def test_ingest_archive_records_data_source(
 
     registry_row = schema_conn.execute(
         """
-        SELECT archive_name, archive_sha256, ingest_count
+        SELECT id, archive_name, archive_sha256, ingest_count
           FROM ingested_archive
         """
     ).fetchone()
     assert registry_row is not None
-    archive_name, archive_hash, ingest_count = registry_row
+    archive_id, archive_name, archive_hash, ingest_count = registry_row
     assert archive_name == "sample.zip"
     assert ingest_count == 1
     expected_hash = hashlib.sha256(archive_path.read_bytes()).hexdigest()
     assert archive_hash == expected_hash
+    assert archive_id == source_archive_id
 
 
 def test_ingest_archive_skips_duplicate_hash(

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import zipfile
+import hashlib
 
 import logging
 from unittest import mock
@@ -9,9 +10,7 @@ from unittest import mock
 import ingest
 
 
-def test_ingest_archive_records_data_source(
-    tmp_path, schema_conn, monkeypatch
-) -> None:
+def _create_sample_archive(tmp_path: Path, filename: str = "sample.zip") -> Path:
     xml_content = """
     <ClinicalDocument xmlns="urn:hl7-org:v3">
       <recordTarget>
@@ -68,10 +67,17 @@ def test_ingest_archive_records_data_source(
     </SubmitObjectsRequest>
     """
 
-    archive_path = tmp_path / "sample.zip"
+    archive_path = tmp_path / filename
     with zipfile.ZipFile(archive_path, "w") as zf:
         zf.writestr("IHE_XDM/Lauren1/DOC0001.XML", xml_content)
         zf.writestr("IHE_XDM/Lauren1/METADATA.XML", metadata_xml)
+    return archive_path
+
+
+def test_ingest_archive_records_data_source(
+    tmp_path, schema_conn, monkeypatch
+) -> None:
+    archive_path = _create_sample_archive(tmp_path, "sample.zip")
 
     parsed_dir = tmp_path / "parsed"
     raw_dir = tmp_path / "raw"
@@ -147,6 +153,50 @@ def test_ingest_archive_records_data_source(
     ).fetchone()[0]
     assert attachment_count == 1
 
+    registry_row = schema_conn.execute(
+        """
+        SELECT archive_name, archive_sha256, ingest_count
+          FROM ingested_archive
+        """
+    ).fetchone()
+    assert registry_row is not None
+    archive_name, archive_hash, ingest_count = registry_row
+    assert archive_name == "sample.zip"
+    assert ingest_count == 1
+    expected_hash = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    assert archive_hash == expected_hash
+
+
+def test_ingest_archive_skips_duplicate_hash(
+    tmp_path, schema_conn, monkeypatch
+) -> None:
+    archive_path = _create_sample_archive(tmp_path, "duplicate.zip")
+
+    parsed_dir = tmp_path / "parsed"
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+
+    monkeypatch.setattr(ingest, "PARSED_DIR", parsed_dir)
+    monkeypatch.setattr(ingest, "RAW_DIR", raw_dir)
+    monkeypatch.setattr(ingest, "DB_PATH", Path(tmp_path / "db" / "records.db"))
+
+    ingest.ingest_archive(schema_conn, archive_path)
+
+    ds_count, ingest_count = schema_conn.execute(
+        "SELECT COUNT(*), MAX(ingest_count) FROM data_source CROSS JOIN ingested_archive"
+    ).fetchone()
+    assert ds_count == 1
+    assert ingest_count == 1
+
+    ingest.ingest_archive(schema_conn, archive_path)
+
+    ds_count_after = schema_conn.execute("SELECT COUNT(*) FROM data_source").fetchone()[0]
+    ingest_count_after = schema_conn.execute(
+        "SELECT ingest_count FROM ingested_archive WHERE archive_name = ?",
+        ("duplicate.zip",),
+    ).fetchone()[0]
+    assert ds_count_after == 1
+    assert ingest_count_after == 1
 
 def test_ingest_archive_persists_allergies_and_insurance(
     tmp_path,

--- a/tests/test_labs_service.py
+++ b/tests/test_labs_service.py
@@ -39,3 +39,56 @@ def test_insert_labs_sets_data_source(
         (patient_id,),
     ).fetchone()
     assert row == (data_source_id,)
+
+
+def test_insert_labs_deduplicates_by_date_and_loinc(
+    schema_conn: sqlite3.Connection,
+) -> None:
+    patient_id = _seed_patient(schema_conn)
+
+    labs = [
+        {
+            "test_name": "Glucose",
+            "loinc": "2345-7",
+            "value": "95",
+            "unit": "mg/dL",
+            "date": "2024-03-01",
+        },
+        {
+            "test_name": "Glucose",
+            "loinc": "2345-7",
+            "value": "96",
+            "unit": "mg/dL",
+            "date": "2024-03-01",
+        },
+        {
+            "test_name": "Glucose",
+            "loinc": "2345-7",
+            "value": "88",
+            "unit": "mg/dL",
+            "date": "2024-03-02",
+        },
+        {
+            "test_name": "Hemoglobin",
+            "loinc": "718-7",
+            "value": "13.2",
+            "unit": "g/dL",
+            "date": "2024-03-01",
+        },
+    ]
+
+    insert_labs(schema_conn, patient_id, labs)
+
+    rows = schema_conn.execute(
+        "SELECT loinc_code, date, result_value FROM lab_result WHERE patient_id = ?",
+        (patient_id,),
+    ).fetchall()
+
+    assert len(rows) == 3
+    observed_pairs = {(row[0], row[1]) for row in rows}
+    expected_pairs = {
+        ("2345-7", "2024-03-01"),
+        ("2345-7", "2024-03-02"),
+        ("718-7", "2024-03-01"),
+    }
+    assert observed_pairs == expected_pairs

--- a/tests/test_upload_components.py
+++ b/tests/test_upload_components.py
@@ -128,11 +128,19 @@ def test_render_upload_page_ingests_archives(monkeypatch, tmp_path):
     stubs = _StreamlitStub(uploads=[stub_file], submit_result=True)
     monkeypatch.setattr(upload_components, "st", stubs)
     monkeypatch.setattr(upload_components, "RAW_ARCHIVE_DIR", tmp_path)
+    monkeypatch.setattr(upload_components, "archive_was_ingested", lambda conn, sha: None)
 
     ingested_paths: List[Path] = []
+    received_hashes: List[str] = []
 
-    def _fake_ingest(conn: sqlite3.Connection, archive_path: Path) -> None:
+    def _fake_ingest(
+        conn: sqlite3.Connection,
+        archive_path: Path,
+        *,
+        archive_sha256: Optional[str] = None,
+    ) -> None:
         ingested_paths.append(archive_path)
+        received_hashes.append(archive_sha256 or "")
 
     monkeypatch.setattr(upload_components, "ingest_archive", _fake_ingest)
 
@@ -155,6 +163,8 @@ def test_render_upload_page_ingests_archives(monkeypatch, tmp_path):
     assert saved_path.parent == tmp_path
     # Filename sanitisation should replace spaces and punctuation with underscores.
     assert saved_path.name == "Patient_Records_.zip"
+    assert len(received_hashes) == 1
+    assert received_hashes[0]
 
     feedback = stubs.session_state.get("upload_feedback")
     assert feedback is not None
@@ -173,10 +183,16 @@ def test_render_upload_page_blocks_oversized_archives(monkeypatch, tmp_path):
     stubs = _StreamlitStub(uploads=[stub_file], submit_result=True)
     monkeypatch.setattr(upload_components, "st", stubs)
     monkeypatch.setattr(upload_components, "RAW_ARCHIVE_DIR", tmp_path)
+    monkeypatch.setattr(upload_components, "archive_was_ingested", lambda conn, sha: None)
 
     ingest_called = False
 
-    def _fake_ingest(conn: sqlite3.Connection, archive_path: Path) -> None:
+    def _fake_ingest(
+        conn: sqlite3.Connection,
+        archive_path: Path,
+        *,
+        archive_sha256: Optional[str] = None,
+    ) -> None:
         nonlocal ingest_called
         ingest_called = True
 
@@ -209,10 +225,16 @@ def test_render_upload_page_rejects_non_zip(monkeypatch, tmp_path):
     stubs = _StreamlitStub(uploads=[stub_file], submit_result=True)
     monkeypatch.setattr(upload_components, "st", stubs)
     monkeypatch.setattr(upload_components, "RAW_ARCHIVE_DIR", tmp_path)
+    monkeypatch.setattr(upload_components, "archive_was_ingested", lambda conn, sha: None)
 
     ingest_called = False
 
-    def _fake_ingest(conn: sqlite3.Connection, archive_path: Path) -> None:
+    def _fake_ingest(
+        conn: sqlite3.Connection,
+        archive_path: Path,
+        *,
+        archive_sha256: Optional[str] = None,
+    ) -> None:
         nonlocal ingest_called
         ingest_called = True
 
@@ -237,3 +259,55 @@ def test_render_upload_page_rejects_non_zip(monkeypatch, tmp_path):
     assert feedback["success"] == []
     assert len(feedback["errors"]) == 1
     assert "not a valid ZIP archive" in feedback["errors"][0]
+
+
+def test_render_upload_page_detects_duplicate_archives(monkeypatch, tmp_path):
+    """Skip ingestion when the archive hash already exists in the registry."""
+    stub_file = _DummyUploadedFile("duplicate.zip", _build_zip_bytes())
+    stubs = _StreamlitStub(uploads=[stub_file], submit_result=True)
+    monkeypatch.setattr(upload_components, "st", stubs)
+    monkeypatch.setattr(upload_components, "RAW_ARCHIVE_DIR", tmp_path)
+
+    def _fake_lookup(conn: sqlite3.Connection, archive_hash: str):
+        return {
+            "archive_name": "duplicate.zip",
+            "archive_sha256": archive_hash,
+            "first_ingested_at": "2025-10-20T05:14:00Z",
+            "last_ingested_at": "2025-10-20T05:14:00Z",
+            "ingest_count": 1,
+        }
+
+    monkeypatch.setattr(upload_components, "archive_was_ingested", _fake_lookup)
+
+    ingest_called = False
+
+    def _fake_ingest(
+        conn: sqlite3.Connection,
+        archive_path: Path,
+        *,
+        archive_sha256: Optional[str] = None,
+    ) -> None:
+        nonlocal ingest_called
+        ingest_called = True
+
+    monkeypatch.setattr(upload_components, "ingest_archive", _fake_ingest)
+
+    rerun_called = {"flag": False}
+
+    def _rerun() -> None:
+        rerun_called["flag"] = True
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        upload_components.render_upload_page(conn, rerun_callback=_rerun)
+    finally:
+        conn.close()
+
+    assert ingest_called is False
+    assert rerun_called["flag"] is True
+
+    feedback = stubs.session_state.get("upload_feedback")
+    assert feedback is not None
+    assert feedback["success"] == []
+    assert len(feedback["errors"]) == 1
+    assert "was previously ingested" in feedback["errors"][0]

--- a/tests/test_upload_components.py
+++ b/tests/test_upload_components.py
@@ -1,0 +1,239 @@
+# Purpose: Validate Streamlit upload workflow for ingestion triggers and safeguards.
+# Author: Codex + Lauren
+# Date: 2025-10-29
+# Tests: pytest -k test_upload_components
+# AI-assisted: This test module was generated with AI assistance.
+"""Unit tests for frontend.upload_components."""
+
+from __future__ import annotations
+
+import io
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import pytest
+import zipfile
+
+from frontend import upload_components
+
+
+@dataclass
+class _DummyUploadedFile:
+    """Test double implementing the UploadedFile interface subset."""
+
+    name: str
+    data: bytes
+    declared_size: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        self._buffer = io.BytesIO(self.data)
+        if self.declared_size is None:
+            self.declared_size = len(self.data)
+
+    @property
+    def size(self) -> Optional[int]:
+        return self.declared_size
+
+    def read(self, size: int | None = -1) -> bytes:
+        return self._buffer.read(size if size is not None else -1)
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        return self._buffer.seek(offset, whence)
+
+    def tell(self) -> int:
+        return self._buffer.tell()
+
+
+def _build_zip_bytes() -> bytes:
+    """Return a minimal ZIP binary payload."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("sample.txt", "payload")
+    buffer.seek(0)
+    return buffer.read()
+
+
+class _FormContext:
+    """No-op context manager emulating streamlit.form."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class _SpinnerContext:
+    """No-op context manager emulating streamlit.spinner."""
+
+    def __init__(self, _label: str) -> None:
+        self.label = _label
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class _StreamlitStub:
+    """Minimal shim around the Streamlit API surface used by upload components."""
+
+    def __init__(
+        self,
+        *,
+        uploads: Iterable[_DummyUploadedFile],
+        submit_result: bool,
+    ) -> None:
+        self._uploads = list(uploads)
+        self._submit_result = submit_result
+        self.session_state: dict[str, object] = {}
+        self.success_messages: List[str] = []
+        self.error_messages: List[str] = []
+        self.warning_messages: List[str] = []
+
+    def header(self, _label: str) -> None:
+        return None
+
+    def caption(self, _label: str) -> None:
+        return None
+
+    def form(self, _label: str) -> _FormContext:
+        return _FormContext()
+
+    def file_uploader(self, *_args, **_kwargs) -> List[_DummyUploadedFile]:
+        return self._uploads
+
+    def form_submit_button(self, *_args, **_kwargs) -> bool:
+        return self._submit_result
+
+    def spinner(self, label: str) -> _SpinnerContext:
+        return _SpinnerContext(label)
+
+    def warning(self, message: str) -> None:
+        self.warning_messages.append(message)
+
+    def success(self, message: str) -> None:
+        self.success_messages.append(message)
+
+    def error(self, message: str) -> None:
+        self.error_messages.append(message)
+
+
+def test_render_upload_page_ingests_archives(monkeypatch, tmp_path):
+    """Ensure uploaded archives are persisted, ingested, and feedback recorded."""
+    stub_file = _DummyUploadedFile("Patient Records!.zip", _build_zip_bytes())
+    stubs = _StreamlitStub(uploads=[stub_file], submit_result=True)
+    monkeypatch.setattr(upload_components, "st", stubs)
+    monkeypatch.setattr(upload_components, "RAW_ARCHIVE_DIR", tmp_path)
+
+    ingested_paths: List[Path] = []
+
+    def _fake_ingest(conn: sqlite3.Connection, archive_path: Path) -> None:
+        ingested_paths.append(archive_path)
+
+    monkeypatch.setattr(upload_components, "ingest_archive", _fake_ingest)
+
+    rerun_called = {"flag": False}
+
+    def _rerun() -> None:
+        rerun_called["flag"] = True
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        upload_components.render_upload_page(conn, rerun_callback=_rerun)
+    finally:
+        conn.close()
+
+    assert rerun_called["flag"] is True
+    assert len(ingested_paths) == 1
+
+    saved_path = ingested_paths[0]
+    assert saved_path.exists()
+    assert saved_path.parent == tmp_path
+    # Filename sanitisation should replace spaces and punctuation with underscores.
+    assert saved_path.name == "Patient_Records_.zip"
+
+    feedback = stubs.session_state.get("upload_feedback")
+    assert feedback is not None
+    assert feedback["errors"] == []
+    assert feedback["success"] == [f"Ingested {saved_path.name}"]
+
+
+def test_render_upload_page_blocks_oversized_archives(monkeypatch, tmp_path):
+    """Verify archives exceeding the size limit are rejected without ingestion."""
+    oversize = upload_components.MAX_ARCHIVE_BYTES + 1
+    stub_file = _DummyUploadedFile(
+        "too_large.zip",
+        _build_zip_bytes(),
+        declared_size=oversize,
+    )
+    stubs = _StreamlitStub(uploads=[stub_file], submit_result=True)
+    monkeypatch.setattr(upload_components, "st", stubs)
+    monkeypatch.setattr(upload_components, "RAW_ARCHIVE_DIR", tmp_path)
+
+    ingest_called = False
+
+    def _fake_ingest(conn: sqlite3.Connection, archive_path: Path) -> None:
+        nonlocal ingest_called
+        ingest_called = True
+
+    monkeypatch.setattr(upload_components, "ingest_archive", _fake_ingest)
+
+    rerun_called = {"flag": False}
+
+    def _rerun() -> None:
+        rerun_called["flag"] = True
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        upload_components.render_upload_page(conn, rerun_callback=_rerun)
+    finally:
+        conn.close()
+
+    assert ingest_called is False
+    assert rerun_called["flag"] is True
+
+    feedback = stubs.session_state.get("upload_feedback")
+    assert feedback is not None
+    assert feedback["success"] == []
+    assert len(feedback["errors"]) == 1
+    assert "larger than the" in feedback["errors"][0]
+
+
+def test_render_upload_page_rejects_non_zip(monkeypatch, tmp_path):
+    """Reject uploads whose content is not a valid ZIP archive."""
+    stub_file = _DummyUploadedFile("notes.zip", b"not-a-zip")
+    stubs = _StreamlitStub(uploads=[stub_file], submit_result=True)
+    monkeypatch.setattr(upload_components, "st", stubs)
+    monkeypatch.setattr(upload_components, "RAW_ARCHIVE_DIR", tmp_path)
+
+    ingest_called = False
+
+    def _fake_ingest(conn: sqlite3.Connection, archive_path: Path) -> None:
+        nonlocal ingest_called
+        ingest_called = True
+
+    monkeypatch.setattr(upload_components, "ingest_archive", _fake_ingest)
+
+    rerun_called = {"flag": False}
+
+    def _rerun() -> None:
+        rerun_called["flag"] = True
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        upload_components.render_upload_page(conn, rerun_callback=_rerun)
+    finally:
+        conn.close()
+
+    assert ingest_called is False
+    assert rerun_called["flag"] is True
+
+    feedback = stubs.session_state.get("upload_feedback")
+    assert feedback is not None
+    assert feedback["success"] == []
+    assert len(feedback["errors"]) == 1
+    assert "not a valid ZIP archive" in feedback["errors"][0]


### PR DESCRIPTION
* Adds an “Upload records” view to the Streamlit sidebar that accepts CCD ZIP files, validates type/size, and triggers ingestion with user-facing success/error feedback. These uploads are now deduped via SHA-256 hashes, with duplicate attempts surfaced in-app.

* Wires ingestion to compute archive hashes once, skips previously ingested archives, and records metadata in a new ingested_archive registry. data_source rows now reference this registry via source_archive_id, with migrations to backfill existing data and UI updates to display archive provenance details.

* Introduces service helpers, migrations, and pytest coverage for the upload workflow, archive registry, lab result deduping (date + LOINC), and schema changes. Documentation and schema change logs updated accordingly.

##Testing

`.venv\Scripts\python.exe -m pytest tests/test_archives_service.py tests/test_data_sources.py tests/test_upload_components.py tests/test_ingest.py tests/test_labs_service.py`